### PR TITLE
Add option allow-pull-fqdn

### DIFF
--- a/properties/import-export.c
+++ b/properties/import-export.c
@@ -1170,6 +1170,13 @@ do_import (const char *path, const char *contents, gsize contents_len, GError **
 			continue;
 		}
 
+		if (NM_IN_STRSET (params[0], NMV_OVPN_TAG_ALLOW_PULL_FQDN)) {
+			if (!args_params_check_nargs_n (params, 0, &line_error))
+				goto handle_line_error;
+			setting_vpn_add_data_item (s_vpn, NM_OPENVPN_KEY_ALLOW_PULL_FQDN, "yes");
+			continue;
+		}
+
 		if (NM_IN_STRSET (params[0], NMV_OVPN_TAG_TUN_IPV6)) {
 			if (!args_params_check_nargs_n (params, 0, &line_error))
 				goto handle_line_error;
@@ -1882,6 +1889,9 @@ do_export_create (NMConnection *connection, const char *path, GError **error)
 
 	if (nm_streq0 (nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_REMOTE_RANDOM), "yes"))
 		args_write_line (f, NMV_OVPN_TAG_REMOTE_RANDOM);
+
+    if (nm_streq0 (nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_ALLOW_PULL_FQDN), "yes"))
+            args_write_line (f, NMV_OVPN_TAG_ALLOW_PULL_FQDN);
 
 	if (nm_streq0 (nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_TUN_IPV6), "yes"))
 		args_write_line (f, NMV_OVPN_TAG_TUN_IPV6);

--- a/properties/nm-openvpn-dialog.ui
+++ b/properties/nm-openvpn-dialog.ui
@@ -1287,6 +1287,25 @@ config: remote-random</property>
                   </packing>
                 </child>
                 <child>
+                  <object class="GtkCheckButton" id="allow_pull_fqdn_checkbutton">
+                    <property name="label" translatable="yes">Allow Pull FQDN</property>
+                    <property name="use_action_appearance">False</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Allow client to pull DNS names from server
+config: allow-pull-fqdn</property>
+                    <property name="use_underline">True</property>
+                    <property name="xalign">0</property>
+                    <property name="draw_indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">9</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkCheckButton" id="tun_ipv6_checkbutton">
                     <property name="label" translatable="yes">IPv6 tun link</property>
                     <property name="use_action_appearance">False</property>
@@ -1302,7 +1321,7 @@ config: tun-ipv6</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">9</property>
+                    <property name="position">10</property>
                   </packing>
                 </child>
                 <child>
@@ -1369,7 +1388,7 @@ config: ping-exit | ping-restart &lt;n&gt;</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">10</property>
+                    <property name="position">11</property>
                   </packing>
                 </child>
                 <child>
@@ -1416,7 +1435,7 @@ config: ping &lt;n&gt;</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">10</property>
+                    <property name="position">12</property>
                   </packing>
                 </child>
                 <child>
@@ -1438,7 +1457,7 @@ config: float</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">11</property>
+                    <property name="position">13</property>
                   </packing>
                 </child>
                 <child>
@@ -1485,7 +1504,7 @@ config: max-routes &lt;n&gt;</property>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">12</property>
+                    <property name="position">14</property>
                   </packing>
                 </child>
               </object>

--- a/properties/nm-openvpn-editor.c
+++ b/properties/nm-openvpn-editor.c
@@ -682,6 +682,7 @@ sk_file_chooser_filter_new (void)
 }
 
 static const char *const advanced_keys[] = {
+	NM_OPENVPN_KEY_ALLOW_PULL_FQDN,
 	NM_OPENVPN_KEY_AUTH,
 	NM_OPENVPN_KEY_CIPHER,
 	NM_OPENVPN_KEY_COMP_LZO,
@@ -1643,6 +1644,7 @@ advanced_dialog_new (GHashTable *hash, const char *contype)
 
 
 	_builder_init_toggle_button (builder, "remote_random_checkbutton", _hash_get_boolean (hash, NM_OPENVPN_KEY_REMOTE_RANDOM));
+	_builder_init_toggle_button (builder, "allow_pull_fqdn_checkbutton", _hash_get_boolean (hash, NM_OPENVPN_KEY_ALLOW_PULL_FQDN));
 	_builder_init_toggle_button (builder, "tun_ipv6_checkbutton", _hash_get_boolean (hash, NM_OPENVPN_KEY_TUN_IPV6));
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "cipher_combo"));
@@ -1977,6 +1979,10 @@ advanced_dialog_new_hash_from_dialog (GtkWidget *dialog)
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "remote_random_checkbutton"));
 	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget)))
 		g_hash_table_insert (hash, NM_OPENVPN_KEY_REMOTE_RANDOM, g_strdup ("yes"));
+
+    widget = GTK_WIDGET (gtk_builder_get_object (builder, "allow_pull_fqdn_checkbutton"));
+    	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget)))
+    		g_hash_table_insert (hash, NM_OPENVPN_KEY_ALLOW_PULL_FQDN, g_strdup ("yes"));
 
 	widget = GTK_WIDGET (gtk_builder_get_object (builder, "tun_ipv6_checkbutton"));
 	if (gtk_toggle_button_get_active (GTK_TOGGLE_BUTTON (widget)))

--- a/shared/nm-service-defines.h
+++ b/shared/nm-service-defines.h
@@ -28,6 +28,7 @@
 #define NM_DBUS_INTERFACE_OPENVPN  "org.freedesktop.NetworkManager.openvpn"
 #define NM_DBUS_PATH_OPENVPN       "/org/freedesktop/NetworkManager/openvpn"
 
+#define NM_OPENVPN_KEY_ALLOW_PULL_FQDN           "allow-pull-fqdn"
 #define NM_OPENVPN_KEY_AUTH                      "auth"
 #define NM_OPENVPN_KEY_CA                        "ca"
 #define NM_OPENVPN_KEY_CERT                      "cert"

--- a/shared/utils.h
+++ b/shared/utils.h
@@ -22,6 +22,7 @@
 #ifndef UTILS_H
 #define UTILS_H
 
+#define NMV_OVPN_TAG_ALLOW_PULL_FQDN    "allow-pull-fqdn"
 #define NMV_OVPN_TAG_AUTH               "auth"
 #define NMV_OVPN_TAG_AUTH_NOCACHE       "auth-nocache"
 #define NMV_OVPN_TAG_NCP_DISABLE        "ncp-disable"

--- a/src/nm-openvpn-service.c
+++ b/src/nm-openvpn-service.c
@@ -140,6 +140,7 @@ typedef struct {
 } ValidProperty;
 
 static const ValidProperty valid_properties[] = {
+	{ NM_OPENVPN_KEY_ALLOW_PULL_FQDN,           G_TYPE_BOOLEAN, 0, 0, FALSE },
 	{ NM_OPENVPN_KEY_AUTH,                      G_TYPE_STRING, 0, 0, FALSE },
 	{ NM_OPENVPN_KEY_CA,                        G_TYPE_STRING, 0, 0, FALSE },
 	{ NM_OPENVPN_KEY_CERT,                      G_TYPE_STRING, 0, 0, FALSE },
@@ -1442,6 +1443,10 @@ nm_openvpn_start_openvpn_binary (NMOpenvpnPlugin *plugin,
 	tmp = nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_REMOTE_RANDOM);
 	if (nm_streq0 (tmp, "yes"))
 		args_add_strv (args, "--remote-random");
+
+	tmp = nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_ALLOW_PULL_FQDN);
+	if (nm_streq0 (tmp, "yes"))
+		args_add_strv (args, "--allow-pull-fqdn");
 
 	tmp = nm_setting_vpn_get_data_item (s_vpn, NM_OPENVPN_KEY_TUN_IPV6);
 	if (nm_streq0 (tmp, "yes"))


### PR DESCRIPTION
It would be great if we could add --allow-pull-fqdn to the openvpn arguments.